### PR TITLE
Matter-165: Connecting to second SSID

### DIFF
--- a/src/platform/ESP32/ConnectivityManagerImpl.h
+++ b/src/platform/ESP32/ConnectivityManagerImpl.h
@@ -1,4 +1,4 @@
-/*
+ /*
  *
  *    Copyright (c) 2020-2021 Project CHIP Authors
  *    Copyright (c) 2018 Nest Labs, Inc.
@@ -118,6 +118,11 @@ private:
     bool _CanStartWiFiScan();
     void _OnWiFiScanDone();
     void _OnWiFiStationProvisionChange();
+
+public:
+    CHIP_ERROR SetWiFiStationProvision(wifi_config_t&);
+
+private:
 
 #if CHIP_CONFIG_ENABLE_ICD_SERVER
     CHIP_ERROR _SetPollingInterval(System::Clock::Milliseconds32 pollingInterval);

--- a/src/platform/ESP32/NetworkCommissioningDriver.cpp
+++ b/src/platform/ESP32/NetworkCommissioningDriver.cpp
@@ -124,17 +124,6 @@ CHIP_ERROR ESPWiFiDriver::Init(NetworkStatusChangeCallback * networkStatusChange
     mSavedNetwork.ssidLen = static_cast<uint8_t>(ssidLen);
 
     mStagingNetwork        = mSavedNetwork;
-
-    ChipLogProgress(DeviceLayer, "ZWB INIT STAGING NETWORK: %u", (unsigned int)mStagingNetwork.ssidLen);
-    if (mStagingNetwork.ssidLen >= 4)
-    {
-        ChipLogProgress(DeviceLayer, "ZWB INIT STAGING NETWORK: %c%c%c%c", 
-                        mStagingNetwork.ssid[0], 
-                        mStagingNetwork.ssid[1], 
-                        mStagingNetwork.ssid[2], 
-                        mStagingNetwork.ssid[3]);
-    }
-
     mpScanCallback         = nullptr;
     mpConnectCallback      = nullptr;
     mpStatusChangeCallback = networkStatusChangeCallback;
@@ -226,7 +215,6 @@ CHIP_ERROR ESPWiFiDriver::ConnectWiFiNetwork(const char * ssid, uint8_t ssidLen,
         }
     }
     
-    ChipLogProgress(DeviceLayer, "Disable wifi");
     ReturnErrorOnFailure(ConnectivityMgr().SetWiFiStationMode(ConnectivityManager::kWiFiStationMode_Disabled));
 
     wifi_config_t wifiConfig;


### PR DESCRIPTION
#### [Matter-165](https://bigasssolutions.myjetbrains.com/youtrack/issue/Matter-165/Connecting-to-second-SSID): Connecting to second SSID

I don't like changing our fork of the `connectedhomeip` repo much, but sometimes it's the easiest option.

This change just adds a function called `SetWiFiStationProvision()` to the ESP32 version of the WiFi connectivity manager implementation.  Curiously, most other platforms already have a method like this, but ESP32 is unusual in calling the platform-level code (`esp_wifi_set_config()`) directly from the commissioning driver.  By moving this to the connectivity manager, it can now distinguish between attempts to join a new vs. a previously saved network.  Since the host drives our WiFi connection, we basically need to send a provisioning request to the host in the first case and ignore the second case.  

(Note that I don't think any of the GitHub test failures  below mean much since this isn't the original repo.)
